### PR TITLE
Add message content for convenience of rapid edits

### DIFF
--- a/src/cogs/global.py
+++ b/src/cogs/global.py
@@ -284,7 +284,7 @@ class GlobalCog(commands.Cog, name="Baba Is You"):
 
         filename = datetime.utcnow().strftime(r"render_%Y-%m-%d_%H.%M.%S.gif")
         delta = time() - start
-        msg = f"*Rendered in {delta:.2f} s*"
+        msg = f"`{ctx.message.content}`\n*Rendered in {delta:.2f} s*"
         await ctx.reply(content=msg, file=discord.File(buffer, filename=filename, spoiler=spoiler))
         if extra_buffer is not None and extra_names is not None:
             extra_buffer.seek(0)


### PR DESCRIPTION
Add message content for convenience of rapid edits 
(e.g. fixing a typo)

+rule `tile_baba baba is you tile_keke` copies as `+rule tilebaba baba is you tilekeke` due to markdown formatting