### PR TITLE
Add numpy to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Pillow>=7.0
 jishaku>=1.18
 git+https://github.com/Rapptz/asqlite
 git+https://github.com/Rapptz/discord-ext-menus
+numpy


### PR DESCRIPTION
`numpy` library is used in `src/cogs/render.py`, but it wasn't added as a dependency in `requirements.txt`, this PR adds it.