### PR TITLE
Make tiles with an invalid raw variant input show up as <:ERROR:753724577066123476>

### DIFF
--- a/src/cogs/render.py
+++ b/src/cogs/render.py
@@ -175,6 +175,8 @@ class Renderer:
                     path = f"data/sprites/{constants.BABA_WORLD}/{tile.name}_1.png"
                 elif tile.name == "default":
                     path = f"data/sprites/{constants.BABA_WORLD}/default_{wobble + 1}.png"
+                elif tile.variant_number == -1:
+                    path = f"data/sprites/vanilla/error_0_{wobble + 1}.png"
                 else:
                     source, sprite_name = tile.sprite
                     path = f"data/sprites/{source}/{sprite_name}_{tile.variant_number}_{wobble + 1}.png"

--- a/src/cogs/variants.py
+++ b/src/cogs/variants.py
@@ -482,25 +482,29 @@ def setup(bot: Bot):
         if tile_data is None:
             raise errors.TileDoesntExist(ctx.tile.name, ctx.variant)
         tiling = tile_data.tiling
-
-        if tiling in constants.AUTO_TILINGS:
-            if variant >= 16:
-                raise errors.BadTilingVariant(ctx.tile.name, ctx.variant, tiling)
-        else:
-            dir, anim = split_variant(variant)
-            if dir != 0:
-                if tiling not in constants.DIRECTION_TILINGS or dir not in constants.DIRECTIONS:
-                    raise errors.BadTilingVariant(ctx.tile.name, ctx.variant, tiling)
-            if anim != 0:
-                if anim in constants.SLEEP_VARIANTS.values():
-                    if tiling not in constants.SLEEP_TILINGS:
-                        raise errors.BadTilingVariant(ctx.tile.name, ctx.variant, tiling)
-                else:
-                    if tiling not in constants.ANIMATION_TILINGS or anim not in constants.ANIMATION_VARIANTS.values():
-                        raise errors.BadTilingVariant(ctx.tile.name, ctx.variant, tiling)
-        return {
-            "variant_number": variant
-        }
+        try:
+          if tiling in constants.AUTO_TILINGS:
+              if variant >= 16:
+                  raise Exception
+          else:
+              dir, anim = split_variant(variant)
+              if dir != 0:
+                  if tiling not in constants.DIRECTION_TILINGS or dir not in constants.DIRECTIONS:
+                      raise Exception
+              if anim != 0:
+                  if anim in constants.SLEEP_VARIANTS.values():
+                      if tiling not in constants.SLEEP_TILINGS:
+                          raise Exception
+                  else:
+                      if tiling not in constants.ANIMATION_TILINGS or anim not in constants.ANIMATION_VARIANTS.values():
+                          raise Exception
+          return {
+              "variant_number": variant
+          }
+        except:
+          return {
+                "variant_number": -1
+            }
 
     @handlers.handler(
         pattern=r"|".join(constants.COLOR_NAMES),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59123926/134794050-e8b7a3cd-8dea-4d50-8564-496d1284f309.png)
